### PR TITLE
Update getBTC.conf

### DIFF
--- a/Toolbox/getBTC.conf
+++ b/Toolbox/getBTC.conf
@@ -4,11 +4,13 @@
 # Account name may be as descriptive as necessary, for example, sales activity names, salepersons, location and derivation path of wallet. 
 # Allowed Characters in AccountName: A-Z, a-z, 0-9. Lines beginning with "#" are ignored.
 #
+# Assigning one of the AccountName's to "Default" will make it easy to "forget" to select an account name when you're running getBTCInvoice. You'll just need to use a new index and the other fields that build the BIP-21 URI for the QR Code.
+#
 # FORMAT: 
 # AccountName:ExtendedPublicKey
 #
 # EXAMPLES:
-# Alice:xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj
+# Default:xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj
 # Products:ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP
 # Services:zpub6rVZC52z8ugGany9wytHSPQ3DnfvKNPM4Em2tTLPeE2TGd9i5hmjC2kwXNt8oMHAdXruRQAkuqWYmKraSaip3xfPjTq4zKCAJiYGKpmcZ9B
 


### PR DESCRIPTION
Changed first account name to "Default" to make it easy for getBTCInvoice to not have to choose an account.  See [getBTCInvoice] It doesn't really matter which one has the default name, and it's not required, but just makes it easier if someone only uses one account, or repeatedly uses a "default" account.