### PR TITLE
Update README.md

### DIFF
--- a/Toolbox/getBTCInvoice/README.md
+++ b/Toolbox/getBTCInvoice/README.md
@@ -1,27 +1,29 @@
 ## Table of Contents
 - [Bitcoin Merchants Toolbox][Toolbox]
-  - [getBTCAddress][getBTCAddress]
-  - [getBTCBalance][getBTCBalance]
+  - [getBTCAddress]
+  - [getBTCBalance]
   - **getBTCInvoice**
-  - [getBTCRate][getBTCRate]
+  - [getBTCRate]
 
 # getBTCInvoice
-Function that returns a QR Code containing payment request information for a customer to scan.
+Function that returns a [BIP-21] Payment Protocol compliant string which is supported by most popular Bitcoin wallets.
 
-Follows the [BIP-21][bip21] Payment Protocol which is supported by most popular Bitcoin wallets.
+### Dependencies
+- [getBTCAddress.php][getBTCAddress]
+  - requires [getBTC.conf]
+- [getBTCRate.php][getBTCRate]
 
 ### Inputs
-- Bitcoin Address
+- Account Name
   - Type: string
-  - Restrictions:
-    - Must be a valid Bitcoin address
-  - Description: Address to which the customer must send payment to
+  - Description: Wallet Account where payment will be sent(address will be derived for)
+- Index
+  - Type: integer
+  - Description: Wallet Account where payment will be sent(address will be derived for)
 - Invoice Amount
-  - Type: float
-  - Units: Bitcoin
-  - Restrictions:
-    - Must be greater than or equal to `0.00000546`
-  - Description: Amount (in Bitcoin) that the customer must send
+  - Type: float  (###############.##)
+  - Units: USD
+  - Description: Amount (in USD) that the customer must send
 - Address Label (Optional)
   - Type: string
   - Description: Label that the customer will see in addition to the Address
@@ -30,10 +32,12 @@ Follows the [BIP-21][bip21] Payment Protocol which is supported by most popular 
   - Description: Message that the customer will see as a reason for payment
 
 ### Outputs
-- QR Code
-  - Type: image (binary)
-  - Description: QR Code image data encapsulating the payment request information
-
+- [Result] 
+  - Type: string
+  - Description: [BIP-21] compliant string
+  - Sample outputs:
+    - WIP
+    
 ## Usage
 
 ### Java
@@ -43,7 +47,31 @@ Currently a WIP.
 Currently a WIP.
 
 ### PHP
-Currently a WIP.
+- getBTCInvoice() - Includable function in pure PHP 7.x 
+```php
+  function getBTCInvoice(string $account = 'Default', int $index, float $amount, string $label, string $message): string
+  {
+   $address = getBTCAddress( $account , $index);
+   $BIP21 = "bitcoin:" . $address;
+   if ( $amount > 0 )
+   {
+    $total = getBTCRate( $amount );
+    $BIP21 = $BIP21 . "?amount=". $total;
+   } else {
+    
+   }
+   if ( ! empty( $label )
+   {
+    $BIP21 = $BIP21 . "&label=" . $label;
+    if ( ! empty( $message )
+    {
+     $BIP21 = $BIP21 . "&message=" . $message;
+    }
+   }
+   $BIP21 = str_replace( $string, " ", "%20");
+   return $BIP21;
+  }
+```
 
 ### Python
 Currently a WIP.
@@ -52,8 +80,29 @@ Currently a WIP.
 Currently a WIP.
 
 
-[bip21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
-[Toolbox]: ../
-[getBTCAddress]: ../getBTCAddress/
-[getBTCBalance]: ../getBTCBalance/
-[getBTCRate]: ../getBTCRate/
+[Toolbox]: ./Toolbox/
+[getBTCAddress]: ./Toolbox/getBTCAddress/
+[getBTCBalance]: ./Toolbox/getBTCBalance/
+[getBTCInvoice]: ./Toolbox/getBTCInvoice/
+[getBTCRate]: ./Toolbox/getBTCRate/
+[getBTC.conf]: ./Toolbox/getBTC.conf/
+[Bob Holden]: https://github.com/EAWF
+[Carson Mullins]: https://github.com/Septem151
+[Ian Coleman]: https://github.com/iancoleman
+[BIP-39 Mnemonic Code Converter]: https://github.com/iancoleman/bip39
+[Jan Lindeman]: https://github.com/rgex
+[BitcoinECDSA.php]: https://github.com/BitcoinPHP/BitcoinECDSA.php
+[Kyle Honeycutt]: https://github.com/coinables
+[Building Bitcoin Websites]:https://www.amazon.com/Building-Bitcoin-Websites-Beginners-Development/dp/153494544X
+[Peter N. Steinmetz]: https://github.com/PeterNSteinmetz
+[Andreas M. Antonopoulos]: https://aantonop.com/
+[Mastering Bitcoin, 2nd Edition]: https://github.com/bitcoinbook
+[BIP's]: https://github.com/bitcoin/bips
+[BIP-21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+[BIP-32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+[BIP-39]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+[BIP-44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+[BIP-49]: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
+[BIP-84]: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
+[BIP-173]: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+[SLIP-0132]: https://github.com/satoshilabs/slips/blob/master/slip-0132.md


### PR DESCRIPTION
Creating a QRCode image is out because of permission, ownership, and image maintenance(deletion) conditions on the users server that are out of our control.
Function creates the BIP-21 string only.
Demo site will create the qrcode on the fly using the html/js page from the server.